### PR TITLE
MifareUltralight: fix possible stack corruption

### DIFF
--- a/src/MifareUltralight.cpp
+++ b/src/MifareUltralight.cpp
@@ -56,12 +56,12 @@ NfcTag MifareUltralight::read()
             return NfcTag(nfc->uid.uidByte, nfc->uid.size, NfcTag::TYPE_2);
         }
 
+        index += ULTRALIGHT_READ_SIZE;
+
         if (index >= (messageLength + ndefStartIndex))
         {
             break;
         }
-
-        index += ULTRALIGHT_READ_SIZE;
     }
 
     return NfcTag(nfc->uid.uidByte, nfc->uid.size, NfcTag::TYPE_2, &buffer[ndefStartIndex], messageLength);


### PR DESCRIPTION
In MifareUltralight::read(), the new index has to be checked _after_ incrementing it, otherwise it can lead to a buffer overrun in byte buffer[bufferSize], leading to stack corruption and unpredictable behaviour.